### PR TITLE
support `df` as an optional input for `TabularDataModule`

### DIFF
--- a/cfnet/datasets.py
+++ b/cfnet/datasets.py
@@ -253,11 +253,20 @@ class TabularDataModule:
     backend: str = 'jax'
     data_name: str = ""
 
-    def __init__(self, data_config: dict | DataModuleConfigs):
+    def __init__(
+        self, 
+        data_config: dict | DataModuleConfigs, # Configurator of `TabularDataModule`
+        df: pd.DataFrame = None # Dataframe which overrides `data_dir` in `data_config` (if not None)
+    ):
         self.configs: DataModuleConfigs = validate_configs(
             data_config, DataModuleConfigs
         )
-        self.data = pd.read_csv(self.configs.data_dir)
+        if df is None:
+            self.data = pd.read_csv(self.configs.data_dir)
+        elif isinstance(df, pd.DataFrame):
+            self.data = df
+        else:
+            raise ValueError(f"{type(df).__name__} is not supported as an input type for `TabularDataModule`.")
 
         # update configs
         self._update_configs(self.configs.dict())

--- a/nbs/01_datasets.ipynb
+++ b/nbs/01_datasets.ipynb
@@ -794,15 +794,6 @@
    "display_name": "Python 3.7.15 ('nbdev2')",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.7.15"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "0ac96ee23b95b4118768073706f37cdea4905e0d36379010678a0d912eb0f9ec"
-   }
   }
  },
  "nbformat": 4,

--- a/nbs/01_datasets.ipynb
+++ b/nbs/01_datasets.ipynb
@@ -513,11 +513,20 @@
     "    backend: str = 'jax'\n",
     "    data_name: str = \"\"\n",
     "\n",
-    "    def __init__(self, data_config: dict | DataModuleConfigs):\n",
+    "    def __init__(\n",
+    "        self, \n",
+    "        data_config: dict | DataModuleConfigs, # Configurator of `TabularDataModule`\n",
+    "        df: pd.DataFrame = None # Dataframe which overrides `data_dir` in `data_config` (if not None)\n",
+    "    ):\n",
     "        self.configs: DataModuleConfigs = validate_configs(\n",
     "            data_config, DataModuleConfigs\n",
     "        )\n",
-    "        self.data = pd.read_csv(self.configs.data_dir)\n",
+    "        if df is None:\n",
+    "            self.data = pd.read_csv(self.configs.data_dir)\n",
+    "        elif isinstance(df, pd.DataFrame):\n",
+    "            self.data = df\n",
+    "        else:\n",
+    "            raise ValueError(f\"{type(df).__name__} is not supported as an input type for `TabularDataModule`.\")\n",
     "\n",
     "        # update configs\n",
     "        self._update_configs(self.configs.dict())\n",
@@ -782,9 +791,18 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.13 ('nbdev2')",
+   "display_name": "Python 3.7.15 ('nbdev2')",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.7.15"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "0ac96ee23b95b4118768073706f37cdea4905e0d36379010678a0d912eb0f9ec"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Now, users can directly pass a `pandas.DataFrame` to `TabularDataModule`